### PR TITLE
Rework Lock Screen Unlock Requirement Text

### DIFF
--- a/packages/SystemUI/res-keyguard/values/strings.xml
+++ b/packages/SystemUI/res-keyguard/values/strings.xml
@@ -192,13 +192,13 @@
     <string name="airplane_mode">Airplane mode</string>
 
     <!-- An explanation text that the pattern needs to be solved since the device has just been restarted. [CHAR LIMIT=80] -->
-    <string name="kg_prompt_reason_restart_pattern">Pattern required after session ended</string>
+    <string name="kg_prompt_reason_restart_pattern">User profile session was ended; pattern required.</string>
 
     <!-- An explanation text that the pin needs to be entered since the device has just been restarted. [CHAR LIMIT=80] -->
-    <string name="kg_prompt_reason_restart_pin">PIN required after session ended</string>
+    <string name="kg_prompt_reason_restart_pin">User profile session was ended; PIN required.</string>
 
     <!-- An explanation text that the password needs to be entered since the device has just been restarted. [CHAR LIMIT=80] -->
-    <string name="kg_prompt_reason_restart_password">Password required after session ended</string>
+    <string name="kg_prompt_reason_restart_password">User profile session was ended; password required.</string>
 
     <!-- An explanation text that the pattern needs to be solved since the user hasn't used strong authentication since quite some time. [CHAR LIMIT=80] -->
     <string name="kg_prompt_reason_timeout_pattern">Pattern required for additional security</string>


### PR DESCRIPTION
In an attempt to reduce user confusion and misunderstanding, improve previously submitted change to lock screen PIN/password requirement text, informing the user that the user profile session was ended and now requires a stronger unlock method, rather than state the device was restarted, which isn't always the case for ended sessions on GrapheneOS.